### PR TITLE
Introduce Notify.pm module inside of NephologyServer

### DIFF
--- a/lib/NephologyServer.pm
+++ b/lib/NephologyServer.pm
@@ -36,6 +36,18 @@ sub startup {
 		action     => 'machine_creds',
 	);
 
+	# Notify
+	$r->post('/notify/:boot_mac')->to(
+		controller => 'notify',
+		action     => 'notify',
+	);
+
+	# Discovery
+	$r->post('/install/:boot_mac')->to(
+		controller => 'install',
+		action 	   => 'discovery',
+	);
+
         $self->plugin(Mount => {'/webui' => 'bin/nephology-webui'});
 }
 

--- a/lib/NephologyServer/Install.pm
+++ b/lib/NephologyServer/Install.pm
@@ -180,7 +180,7 @@ sub discovery {
 		domain => '',
 		primary_ip => '',
 		hostname => '',
-		boot_mac => $ohai->{'macaddress'},
+		boot_mac => $boot_mac,
 	);
 	$NodeObject->save;
 

--- a/lib/NephologyServer/Install.pm
+++ b/lib/NephologyServer/Install.pm
@@ -3,11 +3,13 @@ package NephologyServer::Install;
 use strict;
 use File::Temp;
 use YAML;
+use JSON;
 use Mojo::Base 'Mojolicious::Controller';
 
 use NephologyServer::Config;
 use NephologyServer::DB;
 use NephologyServer::Validate;
+use Node;
 use Node::Manager;
 use MapCasteRule::Manager;
 
@@ -144,6 +146,37 @@ sub install_machine {
 	};
 
 	$self->render(json => $install_list);
+}
+
+sub discovery {
+	my $self = shift;
+	my $boot_mac = $self->stash("boot_mac");
+	my $json = decode_json($self->req->body);
+
+	my $NodeObject = Node->new(
+		ctime => time,
+		mtime => time,
+		asset_tag => '',
+		admin_user =>  '',
+		admin_password => '',
+		ipmi_user => '',
+		ipmi_password => '',
+		caste_id => '0',
+		status_id => '0',
+		domain => '',
+		primary_ip => '',
+		hostname => '',
+		boot_mac => $json->{'macaddress'},
+	);
+	$NodeObject->save;
+
+	my @rule_list;
+        my $install_list = {
+                'version_required' => 2,
+                'runlist'          => \@rule_list,
+        };
+
+        $self->render(json => $install_list);
 }
 
 # uses global @salt to construct salt string of requested length

--- a/lib/NephologyServer/Notify.pm
+++ b/lib/NephologyServer/Notify.pm
@@ -1,0 +1,45 @@
+package NephologyServer::Notify;
+
+use strict;
+use YAML;
+use Mojo::Base 'Mojolicious::Controller';
+
+use NephologyServer::Config;
+use NephologyServer::Validate;
+use Email::Simple;
+use Email::Send;
+
+sub notify {
+        my $self = shift;
+	my $boot_mac = $self->stash('boot_mac');
+
+        my $Config = NephologyServer::Config::config($self);
+
+	unless(NephologyServer::Validate::validate($self,$boot_mac)) {
+		return 1;
+	}
+
+	# At a later time we may want to conditionalize this function call
+	# based on a value from our config.yaml file. That way we can
+	# turn on and off notification events.
+	_email($self, $Config);
+
+	return 1;	
+}
+
+sub _email {
+	my $self = shift;
+	my $Config = shift;
+
+	my $email = Email::Simple->create(
+		header => [
+			To => $self->param('to'),
+			From => $self->param('from'),
+			Subject => $self->param('subject'),
+		],
+		body => $self->param('body'),
+	);
+
+	Email::Send->new({mailer => 'Sendmail'})->send($email);
+}
+1;


### PR DESCRIPTION
This patch introduces Notify.pm which allows us to programmatically send a REST request to the Nephology Server. Notify method will then send an email to an address to notify anyone of an install.

Two new modules are introduced: Email::Send and Email::Simple.
